### PR TITLE
safe chunk size for public networks

### DIFF
--- a/lib/gelf.rb
+++ b/lib/gelf.rb
@@ -6,7 +6,7 @@ require 'digest/sha2'
 
 class Gelf
 
-  MAX_CHUNK_SIZE = 8154
+  MAX_CHUNK_SIZE = 1420
 
   attr_accessor :short_message, :full_message, :level, :host, :line, :file
 


### PR DESCRIPTION
Fat chunks are fantastic when GrayLog2 is local, or available on a solid network without hop packet size limitations. Unfortunately, public networks and the default MTU of 1500 get in the way, MOAR packets are required.
