### PR TITLE
.rvmrc and naming consistency change

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,0 +1,1 @@
+rvm use ruby-1.9.2@gelf_rb_gem --create

--- a/lib/gelf.rb
+++ b/lib/gelf.rb
@@ -8,6 +8,6 @@ module GELF
 end
 
 require 'gelf/severity'
-require 'gelf/ruby_sender'
+require 'gelf/udp_sender'
 require 'gelf/notifier'
 require 'gelf/logger'

--- a/lib/gelf/notifier.rb
+++ b/lib/gelf/notifier.rb
@@ -25,7 +25,7 @@ module GELF
       self.default_options['level'] ||= GELF::UNKNOWN
       self.default_options['facility'] ||= 'gelf-rb'
 
-      @sender = RubyUdpSender.new([[host, port]])
+      @sender = UdpSender.new([[host, port]])
       self.level_mapping = :logger
     end
 

--- a/lib/gelf/udp_sender.rb
+++ b/lib/gelf/udp_sender.rb
@@ -1,6 +1,6 @@
 module GELF
   # Plain Ruby UDP sender.
-  class RubyUdpSender
+  class UdpSender
     attr_accessor :addresses
 
     def initialize(addresses)

--- a/test/test_udp_sender.rb
+++ b/test/test_udp_sender.rb
@@ -1,10 +1,10 @@
 require 'helper'
 
-class TestRubyUdpSender < Test::Unit::TestCase
+class TestUdpSender < Test::Unit::TestCase
   context "with ruby sender" do
     setup do
       @addresses = [['localhost', 12201], ['localhost', 12202]]
-      @sender = GELF::RubyUdpSender.new(@addresses)
+      @sender = GELF::UdpSender.new(@addresses)
       @datagrams1 = %w(d1 d2 d3)
       @datagrams2 = %w(e1 e2 e3)
     end


### PR DESCRIPTION
Added .rvmrc to keep gelf-rb dependencies isolated. Moved ruby_sender and associated test to udp_sender since by nature of the language, we're already Ruby so it was redundant and now it follows standard naming conventions. Updated references from RubyUdpSender to UdpSender.
