### PR TITLE
Adding logging file exclusions array to initializer

### DIFF
--- a/test/test_notifier.rb
+++ b/test/test_notifier.rb
@@ -23,6 +23,7 @@ class TestNotifier < Test::Unit::TestCase
     setup do
       Socket.stubs(:gethostname).returns('stubbed_hostname')
       @notifier = GELF::Notifier.new('host', 12345)
+      @notifier_with_exclusions = GELF::Notifier.new('host', 12345,'WAN',{'logging_exclusions' => ['test_notifier']})
       @sender = mock
       @notifier.instance_variable_set('@sender', @sender)
     end
@@ -110,6 +111,11 @@ class TestNotifier < Test::Unit::TestCase
         hash = @notifier.__send__(:extract_hash, { 'version' => '1.0', 'short_message' => 'message' })
         assert_match /test_notifier.rb/, hash['file']
         assert_equal line + 1, hash['line']
+      end
+
+      should "set file and line with exclusions" do
+        hash = @notifier_with_exclusions.__send__(:extract_hash, { 'version' => '1.0', 'short_message' => 'message' })
+        assert_match /shoulda\/context.rb/, hash['file']
       end
 
       should "set timestamp to current time if not set" do


### PR DESCRIPTION
We have a use case where we are creating our own custom Logging device using another Gem called Lumberjack. When using these devices, the file/line reported in Graylog is our custom Logging device rather than the calling code that implements our device. 

Therefore we augmented Gelf-rb such that the original 'lib/gelf' pattern that was checked with an 'include?' is now a regex. Secondly, the initializer allows for an array of patterns to be supplied so that our own custom Logging devices won't be shown as the file/line in Graylog in addition to 'lib/gelf'.

Cheers,
Hank and Obie
