### PR TITLE
Empty log messages generate exceptions in the Notifier class

### DIFF
--- a/lib/gelf/logger.rb
+++ b/lib/gelf/logger.rb
@@ -37,7 +37,7 @@ module GELF
       hash.merge!(self.class.extract_hash_from_exception(message)) if message.is_a?(Exception)
 
       # need to strip out empty messages
-      unless !hash.has_key?('short_message') || hash['short_message'].to_s.empty?
+      if hash.has_key?('short_message') && !hash['short_message'].to_s.empty?
         notify_with_level(level, hash)
       end
     end

--- a/lib/gelf/logger.rb
+++ b/lib/gelf/logger.rb
@@ -23,21 +23,22 @@ module GELF
                             [args[0], default_options['facility']]
                           end
 
+      hash = {}
       if message.is_a?(Hash)
         # Stringify keys.
-        hash = {}
         message.each do |k,v|
           hash[k.to_s] = message[k]
         end
-
-        hash['facility'] = progname
-      else
-        hash = {'short_message' => message, 'facility' => progname}
       end
+      hash['facility'] = progname unless hash.has_key?('facility')
+      hash['short_message'] = message unless hash.has_key?('short_message')
 
       hash.merge!(self.class.extract_hash_from_exception(message)) if message.is_a?(Exception)
 
-      notify_with_level(level, hash)
+      # need to strip out empty messages
+      unless hash['short_message'].to_s.empty?
+        notify_with_level(level, hash)
+      end
     end
 
     # Redefines methods in +Notifier+.

--- a/lib/gelf/logger.rb
+++ b/lib/gelf/logger.rb
@@ -29,14 +29,15 @@ module GELF
         message.each do |k,v|
           hash[k.to_s] = message[k]
         end
+      else
+        hash['short_message'] = message.to_s
       end
       hash['facility'] = progname unless hash.has_key?('facility')
-      hash['short_message'] = message unless hash.has_key?('short_message')
 
       hash.merge!(self.class.extract_hash_from_exception(message)) if message.is_a?(Exception)
 
       # need to strip out empty messages
-      unless hash['short_message'].to_s.empty?
+      unless !hash.has_key?('short_message') || hash['short_message'].to_s.empty?
         notify_with_level(level, hash)
       end
     end

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -134,6 +134,40 @@ class TestLogger < Test::Unit::TestCase
         end
         @logger.add(GELF::INFO, { :short_message => "Some message", :_foo => "bar", "_zomg" => "wat"}, "somefac")
       end
+
+      should "implement add method with level and ignore zero-length message strings" do
+        @logger.expects(:notify_with_level!).never
+        @logger.add(GELF::INFO, "")
+      end
+
+      should "implement add method with level and ignore nil message" do
+        @logger.expects(:notify_with_level!).never
+        @logger.add(GELF::INFO, nil)
+      end
+
+      should "implement add method with level and ignore hash without short_message key" do
+        @logger.expects(:notify_with_level!).never
+        @logger.add(GELF::INFO, { :message => "Some message" })
+      end
+
+      should "implement add method with level and ignore hash with zero-length short_message entry" do
+        @logger.expects(:notify_with_level!).never
+        @logger.add(GELF::INFO, { :short_message => "" })
+      end
+
+      should "implement add method with level and ignore hash with nil short_message entry" do
+        @logger.expects(:notify_with_level!).never
+        @logger.add(GELF::INFO, { :short_message => nil })
+      end
+
+      should "implement add method with level and message and facility from hash" do
+        @logger.expects(:notify_with_level!).with do |level, hash|
+          level == GELF::INFO &&
+          hash['short_message'] == 'Some message' &&
+          hash['facility'] == 'somefac'
+        end
+        @logger.add(GELF::INFO, { :short_message => "Some message", :facility => "somefac" })
+      end
     end
 
     GELF::Levels.constants.each do |const|


### PR DESCRIPTION
Rails likes to log empty lines, particularly ActionView. Unfortunately that triggers an exception in the `Notifier#check_presence_of_mandatory_attributes` method because the `short_message` value is an empty string.
This change ensures that messages send to the Notifier always have a non-empty `short_message` field. Empty log lines and hashes without a `short_message` value will be ignored.
This change also allows to specify the `facility` in the log message if it is a hash which is useful when used in combination with other logging frameworks or even in your logging own code.
