### PR TITLE
Add basic API usage information to README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -6,6 +6,39 @@ Works with Ruby 1.8.7, 1.9.x. and 2.0.x.
 
 {<img src="https://travis-ci.org/Graylog2/gelf-rb.png?branch=master" alt="Build Status" />}[https://travis-ci.org/Graylog2/gelf-rb]
 
+== Usage
+=== Gelf::Notifier
+
+This allows you to sent arbitary messages via UDP to your Graylog2 server.
+
+  n = GELF::Notifier.new("localhost", 12201)
+
+  # Send with custom attributes and an additional parameter "foo"
+  n.notify!(:short_message => "foo", :full_message => "something here\n\nbacktrace?!", :_foo => "bar")
+
+  # Pass any object that responds to .to_hash
+  n.notify!(Exception.new)
+
+=== Gelf::Logger
+
+The Gelf::Logger is compatible with the standard Ruby Logger interface and can be used interchangeably.
+Under the hood it uses Gelf::Notifier to send log messages via UDP to Graylog2.
+
+  logger = GELF::Logger.new("localhost", 12201, "WAN", { :facility => "appname" })
+  
+  logger.debug "foobar"
+  logger.info "foobar"
+  logger.warn "foobar"
+  logger.error "foobar"
+  logger.fatal "foobar"
+  
+  logger << "foobar"
+
+Since it's compatible with the Logger interface, you can also use it in your Rails application:
+
+  # config/environments/production.rb
+  config.logger = GELF::Logger.new("localhost", 12201, "WAN", { :facility => "appname" })
+
 == Note on Patches/Pull Requests
 
 * Fork the project.


### PR DESCRIPTION
This adds some basic API information to the README file, which didn't have any documentation about the API before. Some parts are copied from the wiki.

Signed contributors agreement has been sent to you via email.
