### PR TITLE
Make GELF::Logger#add compatible with Logger#add

### DIFF
--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -21,7 +21,7 @@ class TestLogger < Test::Unit::TestCase
           hash['short_message'] == 'Message' &&
           hash['facility'] == 'gelf-rb'
         end
-        @logger.add(GELF::INFO, 'Message')
+        @logger.add(GELF::INFO, nil, 'Message')
       end
 
       # logger.add(Logger::INFO, RuntimeError.new('Boom!'))
@@ -32,7 +32,7 @@ class TestLogger < Test::Unit::TestCase
           hash['full_message'] =~ /^Backtrace/ &&
           hash['facility'] == 'gelf-rb'
         end
-        @logger.add(GELF::INFO, RuntimeError.new('Boom!'))
+        @logger.add(GELF::INFO, nil, RuntimeError.new('Boom!'))
       end
 
       # logger.add(Logger::INFO) { 'Message' }
@@ -42,7 +42,7 @@ class TestLogger < Test::Unit::TestCase
           hash['short_message'] == 'Message' &&
           hash['facility'] == 'gelf-rb'
         end
-        @logger.add(GELF::INFO) { 'Message' }
+        @logger.add(GELF::INFO, nil, nil) { 'Message' }
       end
 
       # logger.add(Logger::INFO) { RuntimeError.new('Boom!') }
@@ -53,7 +53,7 @@ class TestLogger < Test::Unit::TestCase
           hash['full_message'] =~ /^Backtrace/ &&
           hash['facility'] == 'gelf-rb'
         end
-        @logger.add(GELF::INFO) { RuntimeError.new('Boom!') }
+        @logger.add(GELF::INFO, nil, nil) { RuntimeError.new('Boom!') }
       end
 
       # logger.add(Logger::INFO, 'Message', 'Facility')
@@ -66,7 +66,7 @@ class TestLogger < Test::Unit::TestCase
         @logger.add(GELF::INFO, 'Message', 'Facility')
       end
 
-      # logger.add(Logger::INFO, 'Message', 'Facility')
+      # logger.add(Logger::INFO, 'Message', nil)
       should "use facility from initialization if facility is nil" do
         logger = GELF::Logger.new('localhost', 12202, 'WAN', :facility => 'foo-bar')
         logger.expects(:notify_with_level!).with do |level, hash|
@@ -77,7 +77,7 @@ class TestLogger < Test::Unit::TestCase
         logger.add(GELF::INFO, 'Message', nil)
       end
 
-      # logger.add(Logger::INFO, 'Message', 'Facility')
+      # logger.add(Logger::INFO, 'Message', nil)
       should "use default facility if facility is nil" do
         @logger.expects(:notify_with_level!).with do |level, hash|
           level == GELF::INFO &&
@@ -98,17 +98,17 @@ class TestLogger < Test::Unit::TestCase
         @logger.add(GELF::INFO, RuntimeError.new('Boom!'), 'Facility')
       end
 
-      # logger.add(Logger::INFO, 'Facility') { 'Message' }
+      # logger.add(Logger::INFO, nil, 'Facility') { 'Message' }
       should "implement add method with level and facility from parameters, message from block" do
         @logger.expects(:notify_with_level!).with do |level, hash|
           level == GELF::INFO &&
           hash['short_message'] == 'Message' &&
           hash['facility'] == 'Facility'
         end
-        @logger.add(GELF::INFO, 'Facility') { 'Message' }
+        @logger.add(GELF::INFO, nil, 'Facility') { 'Message' }
       end
 
-      # logger.add(Logger::INFO, 'Facility') { RuntimeError.new('Boom!') }
+      # logger.add(Logger::INFO, nil, 'Facility') { RuntimeError.new('Boom!') }
       should "implement add method with level and facility from parameters, exception from block" do
         @logger.expects(:notify_with_level!).with do |level, hash|
           level == GELF::INFO &&
@@ -116,7 +116,7 @@ class TestLogger < Test::Unit::TestCase
           hash['full_message'] =~ /^Backtrace/ &&
           hash['facility'] == 'Facility'
         end
-        @logger.add(GELF::INFO, 'Facility') { RuntimeError.new('Boom!') }
+        @logger.add(GELF::INFO, nil, 'Facility') { RuntimeError.new('Boom!') }
       end
 
 
@@ -144,7 +144,7 @@ class TestLogger < Test::Unit::TestCase
         @logger.add(GELF::INFO, { :short_message => "Some message", :_foo => "bar", "_zomg" => "wat"})
       end
 
-      # logger.add(Logger::INFO, "somefac", { :short_message => "Some message", :_foo => "bar", "_zomg" => "wat" })
+      # logger.add(Logger::INFO, { :short_message => "Some message", :_foo => "bar", "_zomg" => "wat" }, 'somefac')
       should "implement add method with level and message from hash, facility from parameters and some additional fields" do
         @logger.expects(:notify_with_level!).with do |level, hash|
           level == GELF::INFO &&
@@ -160,19 +160,31 @@ class TestLogger < Test::Unit::TestCase
     GELF::Levels.constants.each do |const|
       # logger.error "Argument #{ @foo } mismatch."
       should "call add with level #{const} from method name, message from parameter" do
-        @logger.expects(:add).with(GELF.const_get(const), 'message')
+        @logger.expects(:notify_with_level!).with do |level, hash|
+          level == GELF.const_get(const) &&
+          hash['short_message'] == 'message' &&
+          hash['facility'] == 'gelf-rb'
+        end
         @logger.__send__(const.downcase, 'message')
       end
 
       # logger.fatal { "Argument 'foo' not given." }
       should "call add with level #{const} from method name, message from block" do
-        @logger.expects(:add).with(GELF.const_get(const), 'message')
+        @logger.expects(:notify_with_level!).with do |level, hash|
+          level == GELF.const_get(const) &&
+          hash['short_message'] == 'message' &&
+          hash['facility'] == 'gelf-rb'
+        end
         @logger.__send__(const.downcase) { 'message' }
       end
 
       # logger.info('initialize') { "Initializing..." }
       should "call add with level #{const} from method name, facility from parameter, message from block" do
-        @logger.expects(:add).with(GELF.const_get(const), 'message', 'facility')
+        @logger.expects(:notify_with_level!).with do |level, hash|
+          level == GELF.const_get(const) &&
+          hash['short_message'] == 'message' &&
+          hash['facility'] == 'facility'
+        end
         @logger.__send__(const.downcase, 'facility') { 'message' }
       end
 


### PR DESCRIPTION
This changes the interface of `GELF::Logger#add` to be the same as Ruby's `Logger#add`.

Before the change the `GELF::Logger` would loose messages if its `#add` method was used like `Logger#add`.

This changes the code to use the new interface and uses the same technique as Ruby's `Logger#add` to check for messages and facilities in the body of `#add`.

For more information: https://github.com/Graylog2/gelf-rb/issues/26

I really hope this doesn't break anything, since I changed assertions in the tests to conform to the Ruby Logger interface. I also hope I didn't make a mistake while doing this. Careful review would be appreciated :)
