### PR TITLE
Add tagged logging support

### DIFF
--- a/lib/gelf/logger.rb
+++ b/lib/gelf/logger.rb
@@ -2,7 +2,7 @@ module GELF
   # Methods for compatibility with Ruby Logger.
   module LoggerCompatibility
 
-    attr_accessor :formatter
+    attr_accessor :formatter, :log_tags
 
     # Use it like Logger#add... or better not to use at all.
     def add(level, message = nil, progname = nil, &block)
@@ -33,7 +33,7 @@ module GELF
       end
 
       # Include tags in message hash
-      Array(default_options['tags']).each_with_index do |tag_name, index|
+      Array(log_tags).each_with_index do |tag_name, index|
         message_hash.merge!("_#{tag_name}" => current_tags[index]) if current_tags[index]
       end
 
@@ -82,8 +82,9 @@ module GELF
   #
   # Tagged logging (with tags from rack middleware) (order of tags is important)
   # Adds custom gelf messages: { '_uuid_name' => <uuid>, '_remote_ip_name' => <remote_ip> }
+  #     config.logger = GELF::Logger.new("localhost", 12201, "LAN", { :facility => "appname" })
   #     config.log_tags = [:uuid, :remote_ip]
-  #     config.logger = GELF::Logger.new("localhost", 12201, "LAN", { :facility => "appname", :tags => config.log_tags })
+  #     config.logger.log_tags = [:uuid_name, :remote_ip_name] # Same order as config.log_tags
   class Logger < Notifier
     include LoggerCompatibility
   end

--- a/lib/gelf/logger.rb
+++ b/lib/gelf/logger.rb
@@ -32,6 +32,11 @@ module GELF
         message_hash.merge!(self.class.extract_hash_from_exception(message))
       end
 
+      # Include tags in message hash
+      Array(default_options['tags']).each_with_index do |tag_name, index|
+        message_hash.merge!("_#{tag_name}" => current_tags[index]) if current_tags[index]
+      end
+
       notify_with_level(level, message_hash)
     end
 
@@ -51,12 +56,34 @@ module GELF
     def <<(message)
       notify_with_level(GELF::UNKNOWN, 'short_message' => message)
     end
+
+    def tagged(*tags)
+      new_tags = push_tags(*tags)
+      yield self
+    ensure
+      current_tags.pop(new_tags.size)
+    end
+
+    def push_tags(*tags)
+      tags.flatten.reject{ |t| t.respond_to?(:empty?) ? !!t.empty? : !t }.tap do |new_tags|
+        current_tags.concat new_tags
+      end
+    end
+
+    def current_tags
+      Thread.current[:gelf_tagged_logging_tags] ||= []
+    end
   end
 
   # Graylog2 notifier, compatible with Ruby Logger.
   # You can use it with Rails like this:
   #     config.logger = GELF::Logger.new("localhost", 12201, "WAN", { :facility => "appname" })
   #     config.colorize_logging = false
+  #
+  # Tagged logging (with tags from rack middleware) (order of tags is important)
+  # Adds custom gelf messages: { '_uuid_name' => <uuid>, '_remote_ip_name' => <remote_ip> }
+  #     config.log_tags = [:uuid, :remote_ip]
+  #     config.logger = GELF::Logger.new("localhost", 12201, "LAN", { :facility => "appname", :tags => config.log_tags })
   class Logger < Notifier
     include LoggerCompatibility
   end

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -210,6 +210,38 @@ class TestLogger < Test::Unit::TestCase
       @logger.formatter
     end
 
+    context "#tagged" do
+      # logger.tagged("TAG") { logger.info "Message" }
+      should "support tagged method" do
+        @logger.expects(:notify_with_level!).with do |level, hash|
+          level == GELF::INFO &&
+          hash['short_message'] == 'Message' &&
+          hash['facility'] == 'gelf-rb'
+        end
+
+        str = "TAG"
+        str.stubs(:blank?).returns(true)
+
+        @logger.tagged(str) { @logger.info "Message" }
+      end
+
+      should "set custom gelf message with tag name and tag content" do
+        # I want the first tag with name 'test_tag'
+        @logger.default_options.merge!('tags' => ['test_tag'])
+
+        @logger.expects(:notify_with_level!).with do |level, hash|
+          level == GELF::INFO &&
+          hash['short_message'] == 'Message' &&
+          hash['facility'] == 'gelf-rb' &&
+          hash['_test_tag'] == 'TAG' # TAG should be in the hash
+        end
+
+        str = "TAG"
+        str.stubs(:blank?).returns(false)
+
+        @logger.tagged(str) { @logger.info "Message" }
+      end
+    end
 
     context "close" do
       should "close socket" do

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -227,7 +227,7 @@ class TestLogger < Test::Unit::TestCase
 
       should "set custom gelf message with tag name and tag content" do
         # I want the first tag with name 'test_tag'
-        @logger.default_options.merge!('tags' => ['test_tag'])
+        @logger.log_tags = [:test_tag]
 
         @logger.expects(:notify_with_level!).with do |level, hash|
           level == GELF::INFO &&


### PR DESCRIPTION
This adds support for tagged logging that is compatible with ActiveSupport::TaggedLogging.

I'm open for discussion on whether the initialization for the tagged logging is the right way to go.  In a Rails application config file, I would use it like this:

``` ruby
config.logger = GELF::Logger.new('localhost', 12201, 'WAN', { facility: 'my_application' })
config.log_tags = [:uuid]
config.logger.log_tags = [:request_uuid]
```

From the other pull requests submitted prior to this, they added the tag names in the default_options hash, but this causes that array to be pushed onto Graylog.  We could remove that key from default_options, but that could be an issue if someone would like to use that hash key we choose for their own use.  It also doesn't make sense to me to put configuration in the default options hash, since this hash is the default hash for every message to Graylog.

Instead I'm opting to create an attribute called log_tags on the LoggerCompatibility module which mimics the Rails method.

If this looks ok, I can add to the README.rdoc file on usage.

Thanks to @mitnal since this is heavily inspired by pull request https://github.com/Graylog2/gelf-rb/pull/8
