### PR TITLE
Ignore empty messages logging

### DIFF
--- a/lib/gelf/logger.rb
+++ b/lib/gelf/logger.rb
@@ -5,7 +5,7 @@ module GELF
     attr_accessor :formatter
 
     # Use it like Logger#add... or better not to use at all.
-    def add(level, message = nil, progname = nil)
+    def add(level, message = nil, progname = nil, &block)
       progname ||= default_options['facility']
 
       if message.nil?
@@ -20,9 +20,8 @@ module GELF
       message_hash = { 'facility' => progname }
 
       if message.is_a?(Hash)
-        # Stringify keys.
         message.each do |key, value|
-          message_hash[key.to_s] = value
+          message_hash[key.to_s] = value.to_s
         end
       else
         message_hash['short_message'] = message.to_s
@@ -32,7 +31,9 @@ module GELF
         message_hash.merge!(self.class.extract_hash_from_exception(message))
       end
 
-      notify_with_level(level, message_hash)
+      if message_hash.key?('short_message') && !message_hash['short_message'].empty?
+        notify_with_level(level, message_hash)
+      end
     end
 
     # Redefines methods in +Notifier+.

--- a/lib/gelf/logger.rb
+++ b/lib/gelf/logger.rb
@@ -7,14 +7,11 @@ module GELF
     # Use it like Logger#add... or better not to use at all.
     def add(level, message = nil, progname = nil, &block)
       progname ||= default_options['facility']
+      message ||= block.call unless block.nil?
 
       if message.nil?
-        if block_given?
-          message = yield
-        else
-          message = progname
-          progname = default_options['facility']
-        end
+        message = progname
+        progname = default_options['facility']
       end
 
       message_hash = { 'facility' => progname }


### PR DESCRIPTION
This is basically a replacement for #12 which is stale for a couple years.
Empty messages (looking at you Rails!) are now ignored, to avoid raised errors by `Notifier#check_presence_of_mandatory_attributes`

PS: I signed and sent the CA.
