### PR TITLE
Add additional non-Ruby logger levels for wider compatibility

### DIFF
--- a/lib/gelf/severity.rb
+++ b/lib/gelf/severity.rb
@@ -14,6 +14,11 @@ module GELF
     ERROR   = 3
     FATAL   = 4
     UNKNOWN = 5
+    # Additional non-Ruby Logger levels
+    # These will work in direct mapping mode only, for compatibility with non-Ruby log sources
+    ALERT   = 101
+    CRIT    = 102
+    NOTICE  = 105
   end
 
   include Levels
@@ -29,9 +34,11 @@ module GELF
   # Maps Ruby Logger levels to syslog levels as is.
   DIRECT_MAPPING = {DEBUG   => 7, # Debug
                     INFO    => 6, # Info
-                    # skip 5 Notice
+                    NOTICE  => 5, # Notice
                     WARN    => 4, # Warning
                     ERROR   => 3, # Error
+                    CRIT    => 2, # Critical
                     FATAL   => 2, # Critical
-                    UNKNOWN => 1} # Alert – shouldn't be used
+                    ALERT   => 1, # Alert
+                    UNKNOWN => 1} # Alert - mapping for compatibility
 end

--- a/lib/gelf/severity.rb
+++ b/lib/gelf/severity.rb
@@ -14,31 +14,37 @@ module GELF
     ERROR   = 3
     FATAL   = 4
     UNKNOWN = 5
-    # Additional non-Ruby Logger levels
-    # These will work in direct mapping mode only, for compatibility with non-Ruby log sources
-    ALERT   = 101
-    CRIT    = 102
-    NOTICE  = 105
+    # Additional native syslog severities. These will work in direct mapping mode
+    # only, for compatibility with syslog sources unrelated to Logger.
+    EMERGENCY     = 10
+    ALERT         = 11
+    CRITICAL      = 12
+    WARNING       = 14
+    NOTICE        = 15
+    INFORMATIONAL = 16
   end
 
   include Levels
 
   # Maps Ruby Logger levels to syslog levels as SyslogLogger and syslogger gems. This one is default.
   LOGGER_MAPPING = {DEBUG   => 7, # Debug
-                    INFO    => 6, # Info
+                    INFO    => 6, # Informational
                     WARN    => 5, # Notice
                     ERROR   => 4, # Warning
                     FATAL   => 3, # Error
                     UNKNOWN => 1} # Alert – shouldn't be used
 
-  # Maps Ruby Logger levels to syslog levels as is.
-  DIRECT_MAPPING = {DEBUG   => 7, # Debug
-                    INFO    => 6, # Info
-                    NOTICE  => 5, # Notice
-                    WARN    => 4, # Warning
-                    ERROR   => 3, # Error
-                    CRIT    => 2, # Critical
-                    FATAL   => 2, # Critical
-                    ALERT   => 1, # Alert
-                    UNKNOWN => 1} # Alert - mapping for compatibility
+  # Maps Syslog or Ruby Logger levels directly to standard syslog numerical severities.
+  DIRECT_MAPPING = {DEBUG         => 7, # Debug
+                    INFORMATIONAL => 6, # Informational (syslog source)
+                    INFO          => 6, # Informational (Logger source)
+                    NOTICE        => 5, # Notice
+                    WARNING       => 4, # Warning (syslog source)
+                    WARN          => 4, # Warning (Logger source)
+                    ERROR         => 3, # Error
+                    CRITICAL      => 2, # Critical (syslog source)
+                    FATAL         => 2, # Critical (Logger source)
+                    ALERT         => 1, # Alert (syslog source)
+                    UNKNOWN       => 1, # Alert - shouldn't be used (Logger source)
+                    EMERGENCY     => 0} # Emergency (syslog source)
 end


### PR DESCRIPTION
Since using this library can be used as more than a native ruby logger, it's useful to allow log entries to capture log levels other than the ones that are used in Ruby itself.

In particular, this is for the fluent-plugin-graylog project, which is currently having to map log levels of alert, critical, and notice from incoming messages to other log levels to get them into Graylog via gelf-rb.