### PR TITLE
Opportunistically use Yajl for json encoding

### DIFF
--- a/lib/gelf/notifier.rb
+++ b/lib/gelf/notifier.rb
@@ -2,6 +2,12 @@ require 'gelf/transport/udp'
 require 'gelf/transport/tcp'
 require 'gelf/transport/tcp_tls'
 
+# replace JSON and #to_json with Yajl if available
+begin
+  require 'yajl/json_gem'
+rescue LoadError
+end
+
 module GELF
   # Graylog2 notifier.
   class Notifier


### PR DESCRIPTION
Replace #to_json with a faster Yajl implementation, when Yajl is present.

Also, this fixes the JSON::GeneratorError error: "source sequence is
illegal/malformed utf-8", which happens when source hashes do not have
correct encoding.  In particular, this affects emsearcy/fluent-plugin-gelf,
which may have strings coming in with improper encoding, becuase fluentd
treats all logs as ASCII-8BIT (see fluent/fluentd#215).

There are other opportunities for performance improvements with Yajl, like
using its stream processing to write to the sockets as it syncronously
encodes and/or compresses, but I've ignored those for now as they would
require architectural changes to gelf-rb.