### PR TITLE
Update .travis.yml to use actual repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ deploy:
   gemspec: gelf.gemspec
   on:
     tags: true
-    repo: Graylog2/gelf-rb
+    repo: graylog-labs/gelf-rb


### PR DESCRIPTION
Travis tells me that the Graylog2/gelf-rb repository cannot be found. So I tried out with the account name here and it worked. Maybe this update of .travis.yml to use the **graylog-labs**/gelf-rb repo is something you want.