### PR TITLE
Update jeweler for next release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 group :development do
   gem "shoulda", "~> 2.11.3"
-  gem "jeweler", "~> 2.1.1"
+  gem "jeweler", "< 2.3.7"
   # Because of a dependency chain jeweler->github_api->oauth2->rack,
   # pin the version: Rack 2.0.x doesn't work on < Ruby 2.2
   gem 'rack', '< 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,74 +1,73 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.4.0)
-    builder (3.2.2)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    builder (3.2.3)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     git (1.3.0)
-    github_api (0.14.5)
-      addressable (~> 2.4.0)
-      descendants_tracker (~> 0.0.4)
+    github_api (0.11.3)
+      addressable (~> 2.3)
+      descendants_tracker (~> 0.0.1)
       faraday (~> 0.8, < 0.10)
-      hashie (>= 3.4)
-      oauth2 (~> 1.0)
-    hashie (3.4.4)
+      hashie (>= 1.2)
+      multi_json (>= 1.7.5, < 2.0)
+      nokogiri (~> 1.6.0)
+      oauth2
+    hashie (3.5.6)
     highline (1.7.8)
-    jeweler (2.1.1)
+    jeweler (2.1.2)
       builder
       bundler (>= 1.0)
       git (>= 1.2.5)
-      github_api
+      github_api (~> 0.11.0)
       highline (>= 1.6.15)
       nokogiri (>= 1.5.10)
       rake
       rdoc
       semver
-    json (1.8.6)
-    json (1.8.6-java)
-    jwt (1.5.4)
+    jwt (1.5.6)
     metaclass (0.0.4)
     mini_portile2 (2.1.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    multi_json (1.12.1)
-    multi_xml (0.5.5)
+    multi_json (1.12.2)
+    multi_xml (0.6.0)
     multipart-post (2.0.0)
-    nokogiri (1.6.8)
+    nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
-    nokogiri (1.6.8-java)
-    oauth2 (1.2.0)
-      faraday (>= 0.8, < 0.10)
+    nokogiri (1.6.8.1-java)
+    oauth2 (1.4.0)
+      faraday (>= 0.8, < 0.13)
       jwt (~> 1.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    pkg-config (1.1.7)
     power_assert (0.3.0)
-    rack (1.6.4)
-    rake (11.2.2)
-    rdoc (4.2.2)
-      json (~> 1.4)
+    public_suffix (3.0.0)
+    rack (1.6.8)
+    rake (12.1.0)
+    rdoc (5.1.0)
     semver (1.0.1)
     shoulda (2.11.3)
     test-unit (3.2.1)
       power_assert
-    thread_safe (0.3.5)
-    thread_safe (0.3.5-java)
+    thread_safe (0.3.6)
+    thread_safe (0.3.6-java)
 
 PLATFORMS
   java
   ruby
 
 DEPENDENCIES
-  jeweler (~> 2.1.1)
+  jeweler (< 2.3.7)
   mocha (~> 1.1.0)
   rack (< 2.0)
   shoulda (~> 2.11.3)
   test-unit (~> 3.2.0)
 
 BUNDLED WITH
-   1.14.6
+   1.15.4


### PR DESCRIPTION
I was trying to update the gem and then noticed that rake version etc was giving error
```
`NoMethodError: undefined method `dependencies_for' for #<Bundler::Runtime:0x007fcc140f96e0>
Did you mean?  dependencies
/Users/tessy/.rvm/gems/ruby-2.4.1/gems/jeweler-2.1.1/lib/jeweler/specification.rb:73:in `block in set_jeweler_defaults'
/Users/tessy/.rvm/gems/ruby-2.4.1/gems/jeweler-2.1.1/lib/jeweler/specification.rb:41:in `chdir'
/Users/tessy/.rvm/gems/ruby-2.4.1/gems/jeweler-2.1.1/lib/jeweler/specification.rb:41:in `set_jeweler_defaults'
/Users/tessy/.rvm/gems/ruby-2.4.1/gems/jeweler-2.1.1/lib/jeweler.rb:37:in `initialize'
/Users/tessy/.rvm/gems/ruby-2.4.1/gems/jeweler-2.1.1/lib/jeweler/tasks.rb:52:in `new'
/Users/tessy/.rvm/gems/ruby-2.4.1/gems/jeweler-2.1.1/lib/jeweler/tasks.rb:52:in `jeweler'
/Users/tessy/.rvm/gems/ruby-2.4.1/gems/jeweler-2.1.1/lib/jeweler/tasks.rb:82:in `block in define'
/Users/tessy/.rvm/gems/ruby-2.4.1/gems/rake-12.1.0/exe/rake:27:in `<top (required)>'
/Users/tessy/.rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `eval'
/Users/tessy/.rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `<main>'`
```