### PR TITLE
Prevent mutation of notifier arguments

### DIFF
--- a/lib/gelf/notifier.rb
+++ b/lib/gelf/notifier.rb
@@ -263,14 +263,18 @@ module GELF
       Zlib::Deflate.deflate(hash.to_json).bytes
     end
 
-    def self.stringify_keys(hash)
-      hash.keys.each do |key|
-        value, key_s = hash.delete(key), key.to_s
-        raise ArgumentError.new("Both #{key.inspect} and #{key_s} are present.") if hash.key?(key_s)
-        value = stringify_keys(value) if value.is_a?(Hash)
-        hash[key_s] = value
+    def self.stringify_keys(data)
+      return data unless data.is_a? Hash
+
+      data.each_with_object({}) do |(key, value), obj|
+        key_s = key.to_s
+
+        if (key != key_s) && data.key?(key_s)
+          raise ArgumentError, "Both #{key.inspect} and #{key_s} are present."
+        end
+
+        obj[key_s] = value
       end
-      hash
     end
   end
 end

--- a/test/test_notifier.rb
+++ b/test/test_notifier.rb
@@ -272,6 +272,16 @@ class TestNotifier < Test::Unit::TestCase
       @notifier.notify!({ 'version' => '1.0', 'short_message' => 'message' })
     end
 
+    should "not mutate arguments" do
+      data = { 'version' => '1.0', 'short_message' => 'message', foo: { bar: "BAZ" } }
+      original_hash = data.hash
+
+      @sender.expects(:send_datagrams)
+      @notifier.notify!(data) 
+
+      assert_equal(data.hash, original_hash)
+    end
+
     GELF::Levels.constants.each do |const|
       should "call notify with level #{const} from method name" do
         @notifier.expects(:notify_with_level).with(GELF.const_get(const), { 'version' => '1.0', 'short_message' => 'message' })


### PR DESCRIPTION
Method `GELF::Notifier.stringify_keys` mutates its arguments which leads to mutating of arguments of the `#notify` invocations.

This behaviour is unsafe, and tbh not necessary, because the method returns processed hash, that could be a new object.

Previous behavior:

```ruby
data = { foo: { bar: "BAZ" } }

n = GELF::Notifier.new("localhost", 12201)
n.notify!(:short_message => "foo", :full_message => "something here\n\nbacktrace?!", data)

data # => { "foo" => { "bar" => "BAZ" } } # keys are stringified in the source hash
```

The new one:

```ruby
data = { foo: { bar: "BAZ" } }

n = GELF::Notifier.new("localhost", 12201)
n.notify!(:short_message => "foo", :full_message => "something here\n\nbacktrace?!", data)

data # => { foo: { bar: "BAZ" } } # the source hash not changed
```