### PR TITLE
TLS Improvements and Fixes

### DIFF
--- a/lib/gelf/transport/tcp_tls.rb
+++ b/lib/gelf/transport/tcp_tls.rb
@@ -84,16 +84,21 @@ module GELF
         end
       end
 
-      # These are A-level ciphers as reported from Graylog 2.0.1
-      # which were also available on Ruby using OpenSSL 1.0.2h
-      # A lot of AES-128-CBC based ciphers were not available
-      SECURE_CIPHERS = %w(
-                           AES128-GCM-SHA256
-                           ECDHE-RSA-AES128-GCM-SHA256
-                           DHE-RSA-AES128-GCM-SHA256
-                         ).freeze
+      # Ciphers have to come from the CipherString class, specifically the _TXT_ constants here - https://github.com/jruby/jruby-openssl/blob/master/src/main/java/org/jruby/ext/openssl/CipherStrings.java#L47-L178
       def restrict_ciphers(ctx)
-        ctx.ciphers = SECURE_CIPHERS
+        # This CipherString is will allow the following Ciphers
+        # ECDHE-ECDSA-AES128-SHA256
+        # ECDHE-RSA-AES128-SHA256
+        # ECDH-ECDSA-AES128-SHA256
+        # ECDH-RSA-AES128-SHA256
+        # ECDHE-ECDSA-AES128-SHA
+        # ECDHE-RSA-AES128-SHA
+        # AES128-SHA
+        # ECDH-ECDSA-AES128-SHA
+        # ECDH-RSA-AES128-SHA
+        # DHE-RSA-AES128-SHA
+        
+        ctx.ciphers = "TLSv1:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!ECDSA:!ADH:!IDEA:!3DES" 
       end
 
       def verify_mode

--- a/lib/gelf/transport/tcp_tls.rb
+++ b/lib/gelf/transport/tcp_tls.rb
@@ -86,18 +86,8 @@ module GELF
 
       # Ciphers have to come from the CipherString class, specifically the _TXT_ constants here - https://github.com/jruby/jruby-openssl/blob/master/src/main/java/org/jruby/ext/openssl/CipherStrings.java#L47-L178
       def restrict_ciphers(ctx)
-        # This CipherString is will allow the following Ciphers
-        # ECDHE-ECDSA-AES128-SHA256
-        # ECDHE-RSA-AES128-SHA256
-        # ECDH-ECDSA-AES128-SHA256
-        # ECDH-RSA-AES128-SHA256
-        # ECDHE-ECDSA-AES128-SHA
-        # ECDHE-RSA-AES128-SHA
-        # AES128-SHA
-        # ECDH-ECDSA-AES128-SHA
-        # ECDH-RSA-AES128-SHA
-        # DHE-RSA-AES128-SHA
-        
+        # This CipherString is will allow a variety of 'currently' cryptographically secure ciphers, 
+	# while also retaining a broad level of compatibility
         ctx.ciphers = "TLSv1:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!ECDSA:!ADH:!IDEA:!3DES" 
       end
 


### PR DESCRIPTION
2 Commits.
https://github.com/graylog-labs/gelf-rb/commit/c60c049c5671a31dd2edcde9a377becfcaf3e97a
Adds the ability to allow the SSL Exceptions to rise up into the calling application.
This is very useful when debugging TLS errors, as the current implementation just eats them, leaving the user none-the-wiser as to why things aren't working.

https://github.com/graylog-labs/gelf-rb/commit/28d35996d71a03eaf574233533ec9baf549cb760
Uses the correct syntax for the CipherString. The Jruby wrapper of SSL cannot take CipherNames directly and must use _TXT_ constants from this list - https://github.com/jruby/jruby-openssl/blob/master/src/main/java/org/jruby/ext/openssl/CipherStrings.java#L47-L178
