### PR TITLE
Implemented CA path selection

### DIFF
--- a/lib/gelf/transport/tcp_tls.rb
+++ b/lib/gelf/transport/tcp_tls.rb
@@ -106,7 +106,7 @@ module GELF
 
       def ssl_cert_store
         OpenSSL::X509::Store.new.tap do |store|
-          if @tls_options.key?('no_default_ca') && @tls_options.key?('no_default_ca')
+          if !@tls_options.key?('no_default_ca')
             @tls_options['no_default_ca']
           else
             @tls_options['no_default_ca'] = false

--- a/lib/gelf/transport/tcp_tls.rb
+++ b/lib/gelf/transport/tcp_tls.rb
@@ -107,10 +107,9 @@ module GELF
       def ssl_cert_store
         OpenSSL::X509::Store.new.tap do |store|
           if !@tls_options.key?('no_default_ca')
-            @tls_options['no_default_ca']
-          else
             @tls_options['no_default_ca'] = false
           end
+          
           if !@tls_options['no_default_ca']
             store.set_default_paths
           end

--- a/lib/gelf/transport/tcp_tls.rb
+++ b/lib/gelf/transport/tcp_tls.rb
@@ -106,11 +106,7 @@ module GELF
 
       def ssl_cert_store
         OpenSSL::X509::Store.new.tap do |store|
-          if !@tls_options.key?('no_default_ca')
-            @tls_options['no_default_ca'] = false
-          end
-          
-          if !@tls_options['no_default_ca']
+          unless @tls_options['no_default_ca']
             store.set_default_paths
           end
 


### PR DESCRIPTION
Allows custom CA paths to be selected.
Allows to disable the system CA paths - the flag had been documented but unused.