### PR TITLE
Replace explicit Yajl support with MultiJson

### DIFF
--- a/gelf.gemspec
+++ b/gelf.gemspec
@@ -59,6 +59,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<mocha>, ["~> 1.1.0"])
       s.add_development_dependency(%q<test-unit>, ["~> 3.2.0"])
       s.add_runtime_dependency(%q<json>, [">= 0"])
+      s.add_runtime_dependency(%q<multi_json>, ["~> 1.0"])
     else
       s.add_dependency(%q<shoulda>, ["~> 2.11.3"])
       s.add_dependency(%q<jeweler>, ["~> 2.1.1"])
@@ -66,6 +67,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<mocha>, ["~> 1.1.0"])
       s.add_dependency(%q<test-unit>, ["~> 3.2.0"])
       s.add_dependency(%q<json>, [">= 0"])
+      s.add_dependency(%q<multi_json>, ["~> 1.0"])
     end
   else
     s.add_dependency(%q<shoulda>, ["~> 2.11.3"])
@@ -74,6 +76,7 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<mocha>, ["~> 1.1.0"])
     s.add_dependency(%q<test-unit>, ["~> 3.2.0"])
     s.add_dependency(%q<json>, [">= 0"])
+    s.add_dependency(%q<multi_json>, ["~> 1.0"])
   end
 end
 

--- a/lib/gelf/notifier.rb
+++ b/lib/gelf/notifier.rb
@@ -2,11 +2,7 @@ require 'gelf/transport/udp'
 require 'gelf/transport/tcp'
 require 'gelf/transport/tcp_tls'
 
-# replace JSON and #to_json with Yajl if available
-begin
-  require 'yajl/json_gem'
-rescue LoadError
-end
+require 'multi_json'
 
 module GELF
   # Graylog2 notifier.
@@ -163,7 +159,7 @@ module GELF
       if hash['level'] >= level
         if default_options['protocol'] == GELF::Protocol::TCP
           validate_hash(hash)
-          @sender.send(hash.to_json + "\0")
+          @sender.send(MultiJson.dump(hash) + "\0")
         else
           @sender.send_datagrams(datagrams_from_hash(hash))
         end
@@ -260,7 +256,7 @@ module GELF
     def serialize_hash(hash)
       validate_hash(hash)
 
-      Zlib::Deflate.deflate(hash.to_json).bytes
+      Zlib::Deflate.deflate(MultiJson.dump(hash)).bytes
     end
 
     def self.stringify_keys(data)


### PR DESCRIPTION
Replacement for #64 

By using MultiJson, one can use `oj` or other JSON libraries besides `yajl`, too.

@tessie are you fine with introducing another dependency here?