### PR TITLE
Remove opportunistic loading of `yajl/json_gem`

### DIFF
--- a/lib/gelf/notifier.rb
+++ b/lib/gelf/notifier.rb
@@ -2,12 +2,6 @@ require 'gelf/transport/udp'
 require 'gelf/transport/tcp'
 require 'gelf/transport/tcp_tls'
 
-# replace JSON and #to_json with Yajl if available
-begin
-  require 'yajl/json_gem'
-rescue LoadError
-end
-
 module GELF
   # Graylog2 notifier.
   class Notifier


### PR DESCRIPTION
Requiring `yajl/json_gem` causes `JSON.parse`, `JSON.generate`, `#to_json`, and other built-in methods to be overridden with the faster YAJL implementation. Faster is, as a rule, better so this seems like a positive change overall. However, because this change extends outside of `gelf-rb` and impacts any place JSON is parsed or generated using the standard library interface, it can have surprising and unexpected consequences.

When I updated gelf-rb to version 3.1.0, parts of my app started to behave differently. Specifically, U+2028 and U+2029 characters stopped being escaped within JSON strings. For a Rails app, which already overrides the standard library interface, this can be a problem [1]. (This will only impact folks who use YAJL without `require 'yajl/json_gem'`.)

To remedy this, `yajl/json_gem` is no longer required by default. This makes the optimization of JSON parsing the responsibility of the app/script/person requiring `gelf-rb`.

[1] http://timelessrepo.com/json-isnt-a-javascript-subset