### PR TITLE
Don't submit protocol as if it were message data

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,23 +30,23 @@ GEM
     json (1.8.6-java)
     jwt (1.5.4)
     metaclass (0.0.4)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.4.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.12.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
-    nokogiri (1.6.8)
-      mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
-    nokogiri (1.6.8-java)
+    nokogiri (1.10.1)
+      mini_portile2 (~> 2.4.0)
+    nokogiri (1.10.1-java)
+    nokogiri (1.10.1-x64-mingw32)
+      mini_portile2 (~> 2.4.0)
     oauth2 (1.2.0)
       faraday (>= 0.8, < 0.10)
       jwt (~> 1.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    pkg-config (1.1.7)
     power_assert (0.3.0)
     rack (1.6.4)
     rake (11.2.2)
@@ -62,6 +62,7 @@ GEM
 PLATFORMS
   java
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   jeweler (~> 2.1.1)
@@ -71,4 +72,4 @@ DEPENDENCIES
   test-unit (~> 3.2.0)
 
 BUNDLED WITH
-   1.14.6
+   1.16.3

--- a/lib/gelf.rb
+++ b/lib/gelf.rb
@@ -4,7 +4,7 @@ require 'zlib'
 require 'digest/md5'
 
 module GELF
-  SPEC_VERSION = '1.0'
+  SPEC_VERSION = '1.1'
   module Protocol
     UDP = 0
     TCP = 1

--- a/lib/gelf/notifier.rb
+++ b/lib/gelf/notifier.rb
@@ -180,8 +180,9 @@ module GELF
                        args['level'] ||= GELF::INFO
                        { 'short_message' => object.to_s }
                      end
-
-      hash = default_options.merge(self.class.stringify_keys(args.merge(primary_data)))
+      default_message_data = default_options.dup
+      default_message_data.delete('protocol')
+      hash = default_message_data.merge(self.class.stringify_keys(args.merge(primary_data)))
       convert_hoptoad_keys_to_graylog2(hash)
       set_file_and_line(hash) if @collect_file_and_line
       set_timestamp(hash)


### PR DESCRIPTION
Fixes #79 

Really, I view this as work towards updating `gelf-rb` to the GELF 1.1 specification.